### PR TITLE
Update Launcher.java

### DIFF
--- a/src/org/betacraft/launcher/Launcher.java
+++ b/src/org/betacraft/launcher/Launcher.java
@@ -381,7 +381,7 @@ public class Launcher {
 		// Download the latest libs and natives
 		if (!Launcher.checkDepends() || Launcher.forceUpdate) {
 			if (!Launcher.downloadDepends()) {
-				JOptionPane.showMessageDialog(null, Lang.ERR_NO_CONNECTION, Lang.ERR_DL_FAIL, JOptionPane.ERROR_MESSAGE);
+				
 			}
 		}
 	}


### PR DESCRIPTION
Removes the no connection message.

Should be used for the 1.09_10 update, as in place for the message should be a way to use the latest local natives.zip.