### PR TITLE
Add basic theming support

### DIFF
--- a/lang/English.json
+++ b/lang/English.json
@@ -102,5 +102,6 @@
   "running_game_reading_version_file": "Reading version json file...",
   "java_version_not_supported": "Your Java installation is not supported by this version of the game.\n",
   "java_version_install_recommended": "Would you like to install recommended Java %0?",
-  "java_version_switch_to_recommended": "Would you like to switch to Java %0?"
+  "java_version_switch_to_recommended": "Would you like to switch to Java %0?",
+  "theme": "Theme"
 }

--- a/lang/Polish (alternative).json
+++ b/lang/Polish (alternative).json
@@ -99,5 +99,6 @@
   "running_game_reading_version_file": "Zčytyvańe pliku json versji...",
   "java_version_not_supported": "Ta versja gry ńe jest kompatybilna z vybraną versją Javy.\n",
   "java_version_install_recommended": "Hćawbyś zainstalovać zalecaną versję Javy %0?",
-  "java_version_switch_to_recommended": "Hćawbyś zmieńić versję Javy na zalecaną %0?"
+  "java_version_switch_to_recommended": "Hćawbyś zmieńić versję Javy na zalecaną %0?",
+  "theme": "Motyv"
 }

--- a/lang/Polish (cyrillic).json
+++ b/lang/Polish (cyrillic).json
@@ -99,5 +99,6 @@
   "running_game_reading_version_file": "Зчитиванє пліку json версʼї...",
   "java_version_not_supported": "Та версʼя ґри нє єст компатибілна з тѫ версʼѭ Яви.\n",
   "java_version_install_recommended": "Хцьалбись заїнсталовать залецанѫ версʼѩ Яви %0?",
-  "java_version_switch_to_recommended": "Хцьалбись змєніть версʼѩ Яви на залецанѫ %0?"
+  "java_version_switch_to_recommended": "Хцьалбись змєніть версʼѩ Яви на залецанѫ %0?",
+  "theme": "Mотуb"
 }

--- a/lang/Polish (cyrillic).json
+++ b/lang/Polish (cyrillic).json
@@ -100,5 +100,5 @@
   "java_version_not_supported": "Та версʼя ґри нє єст компатибілна з тѫ версʼѭ Яви.\n",
   "java_version_install_recommended": "Хцьалбись заїнсталовать залецанѫ версʼѩ Яви %0?",
   "java_version_switch_to_recommended": "Хцьалбись змєніть версʼѩ Яви на залецанѫ %0?",
-  "theme": "Mотуb"
+  "theme": "Мотив"
 }

--- a/lang/Polish.json
+++ b/lang/Polish.json
@@ -99,5 +99,6 @@
   "running_game_reading_version_file": "Zczytywanie pliku json wersji...",
   "java_version_not_supported": "Ta wersja gry nie jest kompatybilna z wybraną wersją Javy.\n",
   "java_version_install_recommended": "Chciałbyś zainstalować zalecaną wersję Javy %0?",
-  "java_version_switch_to_recommended": "Chciałbyś zmienić wersję Javy na zalecaną %0?"
+  "java_version_switch_to_recommended": "Chciałbyś zmienić wersję Javy na zalecaną %0?",
+  "theme": "Motyw"
 }

--- a/src/core/FileSystem.c
+++ b/src/core/FileSystem.c
@@ -360,6 +360,7 @@ void bc_file_init() {
     json_object_object_add(settings_java, "installations", json_object_new_array());
 
     json_object_object_add(settings, "language", json_object_new_string("English"));
+    json_object_object_add(settings, "theme", json_object_new_string("Default"));
     json_object_object_add(settings, "discord", json_object_new_boolean(1));
     json_object_object_add(settings, "instance", instance);
     json_object_object_add(settings, "java", settings_java);

--- a/src/core/Settings.c
+++ b/src/core/Settings.c
@@ -14,6 +14,9 @@ void bc_settings_update(bc_settings* settings) {
     json_object_object_get_ex(json, "language", &tmp);
     json_object_set_string(tmp, settings->language);
 
+    json_object_object_get_ex(json, "theme", &tmp);
+    json_object_set_string(tmp, settings->theme);
+
     json_object_object_get_ex(json, "discord", &tmp);
     json_object_set_boolean(tmp, settings->discord);
 
@@ -28,6 +31,7 @@ bc_settings* bc_settings_get() {
 
     settings->discord = jext_get_boolean(json, "discord");
     snprintf(settings->language, sizeof(settings->language), "%s", jext_get_string_dummy(json, "language"));
+    snprintf(settings->theme, sizeof(settings->theme), "%s", jext_get_string_dummy(json, "theme"));
 
     json_object* tmp;
     if (json_object_object_get_ex(json, "instance", &tmp)) {

--- a/src/core/Settings.h
+++ b/src/core/Settings.h
@@ -4,6 +4,7 @@
 #include <limits.h>
 
 typedef struct bc_settings {
+    char theme[32];
     char language[32];
     char instance[PATH_MAX];
     char java_install[PATH_MAX];

--- a/src/ui/AboutWidget.cpp
+++ b/src/ui/AboutWidget.cpp
@@ -109,7 +109,7 @@ AboutWidget::AboutWidget(QWidget *parent)
     _menu->addTab(_aboutSection, bc_translate("about_about_tab"));
     _menu->addTab(_creditsSection, bc_translate("about_credits_tab"));
     _menu->addTab(_licenseSection, bc_translate("about_license_tab"));
-    _menu->setStyleSheet("QTabWidget::tab-bar { alignment: center; } QTabWidget:pane { border-top: 1px solid gray; }");
+    _menu->setObjectName("about");
 
     _layout->setRowMinimumHeight(0, 15);
     _layout->addWidget(_logo, 1, 1, Qt::AlignCenter | Qt::AlignTop);

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -33,17 +33,17 @@ MainWindow::MainWindow(QWidget *parent) :
     _settingsWidget = new SettingsWidget();
 
     _changelog->setReadOnly(true);
-    _changelog->setStyleSheet(".QTextEdit { background-image: url(':/assets/stone.png'); border: 0; color: #e0d0d0; font-size: 15px; padding-left: 10px; }");
+    _changelog->setObjectName("home-changelog");
     _changelog->viewport()->setCursor(Qt::ArrowCursor);
     _changelog->setMarkdown("Loading...");
 
     _playButton->setFixedWidth(120);
     _playButton->setFixedHeight(50);
-    _bottomBackground->setStyleSheet(".QWidget { background-image: url(':/assets/dirt.png'); }");
+    _bottomBackground->setObjectName("home-bottom");
     _logo->setPixmap(QPixmap(":/assets/logo.png"));
     _playButton->setText(bc_translate("play_button"));
 
-    _menu->setStyleSheet("QTabWidget::pane { border: 0; }");
+    _menu->setObjectName("home-menu");
     _menu->addTab(_changelog, bc_translate("tab_changelog"));
     _menu->addTab(_instanceListWidget, bc_translate("tab_instances"));
 
@@ -74,7 +74,7 @@ MainWindow::MainWindow(QWidget *parent) :
         _menu->addTab(new QWidget(this), bc_translate("tab_donate"));
     }
 
-    _instanceLabel->setStyleSheet(".QLabel { color: white; padding-bottom: 10px; }");
+    _instanceLabel->setObjectName("home-instance-label");
 
     _mainLayout->setSpacing(0);
     _mainLayout->setContentsMargins(0, 0, 0, 0);
@@ -85,6 +85,7 @@ MainWindow::MainWindow(QWidget *parent) :
     _progressBar->setValue(0);
     _progressBar->setRange(0, 100);
 
+    _mainLayout->setObjectName("home");
     _mainLayout->addWidget(_menu, 0, 0, 1, 11);
     _mainLayout->addWidget(_progressBar, 1, 0, 1, 11);
     _mainLayout->addWidget(_bottomBackground, 2, 0, 1, 11);

--- a/src/ui/accounts/AccountListItemWidget.cpp
+++ b/src/ui/accounts/AccountListItemWidget.cpp
@@ -12,7 +12,7 @@ AccountListItemWidget::AccountListItemWidget(bc_account a, QWidget* parent)
     _image = new QLabel(this);
     _name = new QLabel(a.username, this);
     _uuid = new QLabel(a.uuid, this);
-    _image->setStyleSheet(".QLabel { margin-right: 4px; }");
+    _image->setObjectName("account-list-item-image");
 
     bc_memory avatar = bc_avatar_get(a.uuid);
 
@@ -24,7 +24,7 @@ AccountListItemWidget::AccountListItemWidget(bc_account a, QWidget* parent)
 
     free(avatar.response);
 
-    _name->setStyleSheet(".QLabel { font-size: 15px; font-weight: bold; }");
+    _name->setObjectName("account-list-item-name");
 
     _layout->addWidget(_image, 0, 0, 3, 1, Qt::AlignLeft);
     _layout->addWidget(_name, 0, 1, 1, 1, Qt::AlignLeft);
@@ -37,7 +37,7 @@ AccountListItemWidget::AccountListItemWidget(bc_account a, QWidget* parent)
     _layout->setSpacing(0);
     _layout->setContentsMargins(3, 3, 3, 3);
 
-    setStyleSheet("QLabel { font-size: 11px; }");
+    setObjectName("account-list-item");
 
     setLayout(_layout);
 }

--- a/src/ui/accounts/AddAccountWidget.cpp
+++ b/src/ui/accounts/AddAccountWidget.cpp
@@ -14,7 +14,7 @@ AddAccountWidget::AddAccountWidget(QWidget* parent)
     _menu = new QTabWidget(this);
     _microsoftWidget = new AddAccountMicrosoftWidget(this);
 
-    _menu->setStyleSheet("QTabWidget::pane { border: 0; }");
+    _menu->setObjectName("add-account-menu");
     _menu->addTab(_microsoftWidget, bc_translate("accounts_microsoft_title"));
 
     _layout->setAlignment(Qt::AlignTop);

--- a/src/ui/assets.qrc
+++ b/src/ui/assets.qrc
@@ -23,6 +23,9 @@
         <file alias="Ukrainian">../../lang/Ukrainian.json</file>
         <file alias="Traditional Chinese">../../lang/Traditional Chinese.json</file>
     </qresource>
+    <qresource prefix="/theme">
+        <file alias="Default">../../theme/Default.qss</file>
+    </qresource>
     <qresource prefix="/">
         <file alias="COPYING.md">../../COPYING.md</file>
         <file alias="java_repo.json">../../java_repo.json</file>

--- a/src/ui/instances/AddInstanceWidget.cpp
+++ b/src/ui/instances/AddInstanceWidget.cpp
@@ -41,7 +41,7 @@ AddInstanceWidget::AddInstanceWidget(QWidget* parent)
     _layout->setContentsMargins(10, 10, 10, 10);
 
     setLayout(_layout);
-    setStyleSheet("QLabel { font-size: 14px; }");
+    setObjectName("add-instance");
 
     setWindowTitle(bc_translate("instance_creation_title"));
     resize(650, 500);

--- a/src/ui/instances/InstanceEditAppearanceWidget.cpp
+++ b/src/ui/instances/InstanceEditAppearanceWidget.cpp
@@ -78,7 +78,7 @@ InstanceEditAppearanceWidget::InstanceEditAppearanceWidget(QWidget* parent)
     _layout->setSpacing(5);
     _layout->setContentsMargins(10, 10, 10, 10);
 
-    setStyleSheet("QLabel { font-size: 14px; }");
+    setObjectName("instance-appearance-edit");
     setLayout(_layout);
 
     connect(_instanceIconBrowseButton, SIGNAL(released()), this, SLOT(onBrowseButtonClicked()));

--- a/src/ui/instances/InstanceEditArgumentsWidget.cpp
+++ b/src/ui/instances/InstanceEditArgumentsWidget.cpp
@@ -18,7 +18,7 @@ InstanceEditArgumentsWidget::InstanceEditArgumentsWidget(QWidget* parent)
     _javaArgumentsTextEdit->setAcceptRichText(false);
     _programArgumentsTextEdit->setAcceptRichText(false);
 
-    _separateArgumentsLabel->setStyleSheet(".QLabel { font-weight: bold; }");
+    _separateArgumentsLabel->setObjectName("separate-args-label");
 
     _javaArgumentsGroup->setTitle(bc_translate("instance_arguments_jvm_title"));
     _programArgumentsGroup->setTitle(bc_translate("instance_arguments_program_title"));
@@ -38,7 +38,7 @@ InstanceEditArgumentsWidget::InstanceEditArgumentsWidget(QWidget* parent)
     _layout->setSpacing(5);
     _layout->setContentsMargins(10, 10, 10, 10);
 
-    setStyleSheet("QLabel { font-size: 14px; }");
+    setObjectName("instance-args-edit");
     setLayout(_layout);
 }
 

--- a/src/ui/instances/InstanceEditServerWidget.cpp
+++ b/src/ui/instances/InstanceEditServerWidget.cpp
@@ -31,7 +31,7 @@ InstanceEditServerWidget::InstanceEditServerWidget(QWidget* parent)
     _layout->setSpacing(5);
     _layout->setContentsMargins(10, 10, 10, 10);
 
-    setStyleSheet("QLabel { font-size: 14px; }");
+    setObjectName("instance-server-edit");
     setLayout(_layout);
 }
 

--- a/src/ui/instances/InstanceEditVersionWidget.cpp
+++ b/src/ui/instances/InstanceEditVersionWidget.cpp
@@ -49,7 +49,7 @@ InstanceEditVersionWidget::InstanceEditVersionWidget(QWidget* parent)
     _layout->setSpacing(5);
     _layout->setContentsMargins(10, 10, 10, 10);
 
-    setStyleSheet("QLabel { font-size: 14px; }");
+    setObjectName("instance-version-edit");
     setLayout(_layout);
 
     connect(_searchButton, SIGNAL(released()), this, SLOT(onSearchButtonClicked()));

--- a/src/ui/instances/InstanceEditWidget.cpp
+++ b/src/ui/instances/InstanceEditWidget.cpp
@@ -30,7 +30,7 @@ InstanceEditWidget::InstanceEditWidget(QWidget* parent)
     _instanceSaveButtonLayout->addWidget(_instanceSaveButton);
     _instanceSaveButtonWidget->setLayout(_instanceSaveButtonLayout);
 
-    _menu->setStyleSheet("QTabWidget::pane { border: 0; }");
+    _menu->setObjectName("edit-instance-menu");
 
     _menu->addTab(_instanceEditAppearanceWidget, bc_translate("instance_tab_appearance"));
 

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -51,6 +51,32 @@ void copyLanguageFiles() {
     free(workDir);
 }
 
+void copyThemeFiles() {
+    char* workDir = bc_file_directory_get_working();
+
+    QString langRelative("theme/");
+
+    QDir dir = QDir(QString(workDir));
+    dir.mkdir(langRelative);
+
+    QString langPath = dir.absoluteFilePath(langRelative);
+    QString langRes(":/theme/");
+
+    QDir langResSourceDir(langRes);
+    foreach(QString f, langResSourceDir.entryList(QDir::Files)) {
+        QString source = QString(langRes + QDir::separator() + f);
+        QString dest = QString(langPath + f + QString(".qss"));
+
+        if (QFile::exists(dest)) {
+            QFile::remove(dest);
+        }
+
+        QFile::copy(source, dest);
+    }
+
+    free(workDir);
+}
+
 void copyJavaRepo() {
     char* workDir = bc_file_directory_get_working();
 
@@ -60,6 +86,16 @@ void copyJavaRepo() {
 
     QFile::copy(source, dest);
     free(workDir);
+}
+
+QString getTheme() {
+    bc_settings* settings = bc_settings_get();
+    QFile file(":/theme/" + QString(settings->theme));
+    file.open(QFile::ReadOnly);
+    QString stylesheet = QLatin1String(file.readAll());
+    free(settings);
+
+    return stylesheet;
 }
 
 void setWorkDir() {
@@ -91,8 +127,10 @@ int main(int argc, char *argv[]) {
     QApplication app(argc, argv);
     app.setWindowIcon(QIcon(":/assets/favicon.ico"));
     app.setStyle("fusion");
+    app.setStyleSheet(getTheme());
 
     copyLanguageFiles();
+    copyThemeFiles();
     copyJavaRepo();
     bc_file_init();
     betacraft_online = bc_network_status();

--- a/src/ui/servers/ServerListItemWidget.cpp
+++ b/src/ui/servers/ServerListItemWidget.cpp
@@ -41,7 +41,7 @@ ServerListItemWidget::ServerListItemWidget(bc_server s, std::unordered_map<QStri
     _layout->setSpacing(0);
     _layout->setContentsMargins(3, 3, 3, 3);
 
-    setStyleSheet("QLabel { font-size: 11px; }");
+    setObjectName("server-list-item");
 
     setLayout(_layout);
 }

--- a/src/ui/settings/SettingsGeneralWidget.cpp
+++ b/src/ui/settings/SettingsGeneralWidget.cpp
@@ -12,26 +12,39 @@ SettingsGeneralWidget::SettingsGeneralWidget(QWidget* parent)
     _layout = new QGridLayout(this);
     _languageLayout = new QVBoxLayout();
     _languageGroup = new QGroupBox(this);
+    _themeLayout = new QVBoxLayout();
+    _themeGroup = new QGroupBox(this);
     _discordLayout = new QVBoxLayout();
     _discordGroup = new QGroupBox("Discord", this);
     _languageCombo = new QComboBox(this);
+    _themeCombo = new QComboBox(this);
     _discordCheckbox = new QCheckBox("Discord Rich Presence", this);
 
     _languageGroup->setTitle(bc_translate("settings_general_language_title"));
+    _themeGroup->setTitle(bc_translate("theme"));
 
     QDir langDir(":/lang/");
     foreach(QString lang, langDir.entryList(QDir::Files)) {
         _languageCombo->addItem(lang);
     }
 
+    QDir themeDir(":/theme/");
+    foreach(QString theme, themeDir.entryList(QDir::Files)) {
+        _themeCombo->addItem(theme);
+    }
+
     bc_settings* settings = bc_settings_get();
     _languageCombo->setCurrentText(QString(settings->language));
+    _themeCombo->setCurrentText(QString(settings->theme));
     _discordCheckbox->setChecked(settings->discord);
 
     free(settings);
 
     _languageLayout->addWidget(_languageCombo);
     _languageGroup->setLayout(_languageLayout);
+
+    _themeLayout->addWidget(_themeCombo);
+    _themeGroup->setLayout(_themeLayout);
 
     _discordLayout->addWidget(_discordCheckbox);
     _discordGroup->setLayout(_discordLayout);
@@ -41,11 +54,13 @@ SettingsGeneralWidget::SettingsGeneralWidget(QWidget* parent)
     _layout->setAlignment(Qt::AlignTop);
 
     _layout->addWidget(_languageGroup, 0, 0, 1, 1);
-    _layout->addWidget(_discordGroup, 1, 0, 1, 1);
+    _layout->addWidget(_themeGroup, 1, 0, 1, 1);
+    _layout->addWidget(_discordGroup, 2, 0, 1, 1);
 
     setLayout(_layout);
 
-    connect(_languageCombo, SIGNAL(currentTextChanged(const QString&)), this, SLOT(onLanguageChange(const QString&)));
+    connect(_languageCombo, SIGNAL(currentTextChanged(QString)), this, SLOT(onLanguageChange(QString)));
+    connect(_themeCombo, SIGNAL(currentTextChanged(QString)), this, SLOT(onThemeChange(QString)));
     connect(_discordCheckbox, SIGNAL(clicked(bool)), this, SLOT(onDiscordCheckboxClicked(bool)));
 }
 
@@ -53,6 +68,17 @@ void SettingsGeneralWidget::onLanguageChange(const QString& lang) {
     bc_settings* settings = bc_settings_get();
 
     snprintf(settings->language, sizeof(settings->language), "%s", lang.toStdString().c_str());
+    bc_settings_update(settings);
+
+    free(settings);
+
+    QApplication::quit();
+}
+
+void SettingsGeneralWidget::onThemeChange(const QString &theme) {
+    bc_settings* settings = bc_settings_get();
+
+    snprintf(settings->theme, sizeof(settings->theme), "%s", theme.toStdString().c_str());
     bc_settings_update(settings);
 
     free(settings);

--- a/src/ui/settings/SettingsGeneralWidget.h
+++ b/src/ui/settings/SettingsGeneralWidget.h
@@ -21,6 +21,7 @@ public:
 
 private slots:
     void onLanguageChange(const QString& lang);
+    void onThemeChange(const QString& theme);
     void onDiscordCheckboxClicked(bool checked);
 
 signals:
@@ -30,9 +31,12 @@ private:
     QGridLayout* _layout;
     QVBoxLayout* _languageLayout;
     QGroupBox* _languageGroup;
+    QVBoxLayout* _themeLayout;
+    QGroupBox* _themeGroup;
     QVBoxLayout* _discordLayout;
     QGroupBox* _discordGroup;
     QComboBox* _languageCombo;
+    QComboBox* _themeCombo;
     QCheckBox* _discordCheckbox;
 };
 

--- a/src/ui/settings/SettingsWidget.cpp
+++ b/src/ui/settings/SettingsWidget.cpp
@@ -17,7 +17,7 @@ SettingsWidget::SettingsWidget(QWidget* parent)
     _settingsGeneralItem = new QListWidgetItem();
     _settingsJavaItem = new QListWidgetItem();
 
-    _sidebar->setStyleSheet("QListWidget { font-size: 12px; }");
+    _sidebar->setObjectName("settings-sidebar");
 
     _settingsGeneralItem->setSizeHint(QSize(30, 30));
     _settingsGeneralItem->setText(bc_translate("tab_settings_general"));

--- a/theme/Default.qss
+++ b/theme/Default.qss
@@ -1,0 +1,89 @@
+/* Home */
+QTextEdit#home-changelog {
+    background-image: url(':/assets/stone.png');
+    border: none;
+    color: #e0d0d0;
+    font-size: 15px;
+    padding-left: 10px;
+}
+
+QWidget#home-bottom {
+    background-image: url(':/assets/dirt.png');
+}
+
+QTabWidget::pane#home-menu {
+    border: none;
+}
+
+QLabel#home-instance-label {
+    color: white;
+    padding-bottom: 10px;
+}
+
+/* About */
+QTabWidget::tab-bar#about {
+    alignment: center;
+}
+
+QTabWidget:pane#about {
+    border-top: 1px solid gray;
+}
+
+/* Settings */
+QListWidget#settings-sidebar {
+    font-size: 14px;
+}
+
+/* Add Account */
+QTabWidget::pane#add-account-menu {
+    border: none;
+}
+
+/* Account List */
+QLabel#account-list-item-image {
+    margin-right: 4px;
+}
+
+QLabel#account-list-item-name {
+    font-size: 15px;
+    font-weight: bold;
+}
+
+QLabel#account-list-item {
+    font-size: 11px;
+}
+
+/* Add Instance */
+QLabel#add-instance {
+    font-size: 14px;
+}
+
+/* Edit Instance */
+QTabWidget::pane#edit-instance-menu {
+    border: none;
+}
+
+QLabel#instance-version-edit {
+    font-size: 14px;
+}
+
+QLabel#instance-args-edit {
+    font-size: 14px;
+}
+
+QLabel#separate-args-label {
+    font-weight: bold;
+}
+
+QLabel#instance-server-edit {
+    font-size: 14px;
+}
+
+QLabel#instance-appearance-edit {
+    font-size: 14px;
+}
+
+/* Server List */
+QLabel#server-list-item {
+    font-size: 1px;
+}


### PR DESCRIPTION
Adds basic support for theming. The `theme` key in language files is only added in English and Polish (all variations). 

We should probably add ids for more widgets (with `setObjectName`) and optimize the style sheet, as currently you are only able to change the style of elements that were already themed with Qt's `setStylesheet`.